### PR TITLE
[add] Multi-stage Build

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,0 +1,10 @@
+FROM maven:3.5-jdk-8 as BUILD
+WORKDIR /usr/src/app
+COPY pom.xml .
+COPY src .
+RUN mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+FROM websphere-liberty:microProfile
+RUN installUtility install  --acceptLicense defaultServer
+COPY server.xml /config/server.xml
+COPY --from=BUILD /usr/src/app/target/*.war /config/apps/


### PR DESCRIPTION
# 変更の概要
Multi stage buildに対応させたDockerfileの追加

# 機能の使い方/バグの再現方法
`docker build . --file ./Dockerfile.multi`

# テスト項目、確認方法
- `docker build . --file ./Dockerfile.multi`を叩くことで、Maven build 含め一気通貫でDocker imagesが作成できること

# 今回保留にしたToDO
- [ ] CIへの組み込み。（.m2のキャッシュ問題が解決しないため）
   - ベースイメージがmavenクリーン環境のため、mvn installのたびに.m2のダウンロードが大量に入り遅くなる
